### PR TITLE
Update FixinatorClient.cfc for better optimized payload retries.

### DIFF
--- a/models/fixinator/FixinatorClient.cfc
+++ b/models/fixinator/FixinatorClient.cfc
@@ -468,7 +468,7 @@ component singleton="true" {
 
 	public function filterPaths(baseDirectory, paths, config) {
 		var f = "";
-		var ignoredPaths = ["/.git/","\.git\","/.svn/","\.svn\", ".git/", ".hg/", "/.hg/"];
+		var ignoredPaths = [".git/",".git\",".svn/",".svn\",".hg/",".hg\"];
 		var ignoredExtensions = ["jpg","png","txt","pdf","dat", "doc","docx","gif","css","zip","bak","exe","pack","log","csv","xsl","xslx","psd","ai", "svg", "ttf", "woff", "ttf", "gz", "tar", "7z", "epub", "mobi", "ppt", "pptx", "swf", "fla", "flv", "m4v","mp3","mp4","DS_Store", "dll", "ico", "class"];
 		var filteredPaths = [];
 		//always ignore git paths

--- a/models/fixinator/FixinatorClient.cfc
+++ b/models/fixinator/FixinatorClient.cfc
@@ -394,8 +394,8 @@ component singleton="true" {
 				sleep(500);
 				return sendPayload(payload=arguments.payload, isRetry=1);
 			}
-		} else if (httpResult.statusCode contains "502" || httpResult.statusCode contains "504") { 
-			//502 BAD GATEWAY or 504 Gateway Timeout - lambda timeout issue
+		} else if (httpResult.statusCode contains "502" || httpResult.statusCode contains "504" || httpResult.statusCode contains "408") { 
+			//502 BAD GATEWAY, 504 Gateway Timeout - lambda timeout issue, or 408 Request Time-out
 			if (arguments.isRetry >= 2) {
 				local.payloadPaths = arrayMap(arguments.payload.files, function(item) {
 					return item.path;
@@ -414,7 +414,7 @@ component singleton="true" {
 					local.div = int( arrayLen(arguments.payload.files) / 2 );
 
 					for (local.p = 1;local.p<=arrayLen(arguments.payload.files);local.p++) {
-						if (local.p < local.div) {
+						if (local.p <= local.div) {
 							arrayAppend(local.payloadA.files, arguments.payload.files[local.p]);
 						} else {
 							arrayAppend(local.payloadB.files, arguments.payload.files[local.p]);


### PR DESCRIPTION
line 397 : Updated to retry on a 408 request time-out since on retry the number of files will be cut in half which may alleviate the amount of processing and prevent the 408 issue.

line 417: Updated the splitting of the payload to split more evenly on a retry.  Was splitting 5 file payload into payloads of 4 files and 1 file prior.