### PR TITLE
Update command arguments

### DIFF
--- a/commands/fixinator.cfc
+++ b/commands/fixinator.cfc
@@ -33,6 +33,8 @@ component extends="commandbox.system.BaseCommand" excludeFromHelp=false {
 	* @listScanners.hint List the types of scanners that are enabled, enabled automatically when verbose=true
 	* @ignorePaths.hint A globber paths pattern to exclude
 	* @ignoreExtensions.hint A list of extensions to exclude
+	* @configFile.hint The full path to a .fixinator.json formatted file to use as configuration
+	* @requestTimeout.hint The amount of time in seconds that this command will wait for a response from the server
 	* @gitLastCommit.hint Scan only files changed in the last git commit
 	* @gitWorkingCopy.hint Scan only files changed since the last commit in the working copy
 	**/
@@ -51,13 +53,18 @@ component extends="commandbox.system.BaseCommand" excludeFromHelp=false {
         boolean listScanners=false,
         string ignorePaths="",
         string ignoreExtensions="",
+        string configFile="",
+		numeric requestTimeout=35,
 		boolean gitLastCommit=false,
 		boolean gitChanged=false,
     )  {
 		var fileInfo = "";
 		var severityLevel = 1;
 		var confLevel = 1;
-		var config = {};
+		var config = {
+			"configFile": configFile,
+			"requestTimeout": requestTimeout
+		};
 		var toFix = [];
 		var paths = [];
 		if (arguments.verbose) {


### PR DESCRIPTION
Was working with Fixinator this past week and ran into a few issues. I wasn't quite sure how to solve them so it seemed like these changes would be a sensible solution. I would love to hear your insight into the problems I was facing.

Request Timeout
We setup a self-hosted Fixinator enterprise instance and have had some issues with timeouts when scanning certain directories. In order to fix this I added a `requestTimeout` argument to the command and passed that into the cfhttp call to the Fixinator server.

Config File
We have a really large project that is too much to scan in one go. We also need to have access to some of the `ignorePatterns` to weed out some of the false positives. We were only able to get `ignorePatterns` working through the .fixinator.json approach.  It looks like the CLI only provides you the ability to ignore entire scanners. To solve this I added a `configFile` argument that lets you specify a config file outside of your current directory. This also allows us to have one config file for the whole project instead of copying it to each directory.